### PR TITLE
Field con vars

### DIFF
--- a/Assets/SourceConsole/Scripts/SourceConsoleHelper.cs
+++ b/Assets/SourceConsole/Scripts/SourceConsoleHelper.cs
@@ -103,6 +103,21 @@ namespace SourceConsole
                 }
             }
 
+            for (int current = 0; current < assemblies.Length; current++)
+            {
+                FieldInfo[] properties = assemblies[current].GetTypes()
+                  .SelectMany(t => t.GetFields())
+                  .Where(m => m.GetCustomAttributes(typeof(AttributeType), true).Length > 0)
+                  .ToArray();
+
+                for (int i = 0; i < properties.Length; i++)
+                {
+                    AttributeType attribute = ExtractAttribute<AttributeType>(properties[i]);
+                    attribute.FieldInfo = properties[i];
+                    result.Add(attribute);
+                }
+            }
+
             return result.ToArray();
         }
 
@@ -132,6 +147,24 @@ namespace SourceConsole
             return default(T);
         }
 
+        public static T ExtractAttribute<T>(FieldInfo method) where T : Attribute
+        {
+            object[] attributes = method.GetCustomAttributes(typeof(T), true);
+            for (int a = 0; a < attributes.Length; a++)
+            {
+                if (attributes[a].GetType() == typeof(T))
+                {
+                    return (T)attributes[a];
+                }
+            }
+            return default(T);
+        }
+
+        /// <summary>
+        /// Given a string of a command, for example 'print "nice meme"', this simply removes the command name, and returns '"nice meme"'
+        /// </summary>
+        /// <param name="parts"></param>
+        /// <returns></returns>
         public static string[] GetArgumentPartsOnly(string[] parts)
         {
             if (parts.Length <= 1) return new string[0]; //if no args

--- a/Assets/SourceConsole/Scripts/UI/Console/ConsoleAutoCompletionController.cs
+++ b/Assets/SourceConsole/Scripts/UI/Console/ConsoleAutoCompletionController.cs
@@ -50,7 +50,17 @@ namespace SourceConsole.UI
             }
             else
             {
-                parametersString += $": {((ConVar)command).PropertyInfo.PropertyType.Name}";
+                string type;
+                if (((ConVar)command).PropertyInfo != null)
+                {
+                    type = ((ConVar)command).PropertyInfo.PropertyType.Name;
+                }
+                else
+                {
+                    type = ((ConVar)command).FieldInfo.FieldType.Name;
+                }
+
+                parametersString += $": {type}";
             }
 
             commandName.text = $"{command.GetName()} {parametersString}";

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ I found myself commonly binding all sorts of development functions to obscure ke
 
 ## Other developer consoles
 
-Of course, there are plenty of other developer consoles out there on the GitHub asset store, but none of them quite appealed to me, and so I came up with the idea to copy off the Source engine's console.
+Of course, there are plenty of other developer consoles out there on the Unity asset store, but none of them quite appealed to me, and so I came up with the idea to copy off the Source engine's console.
 
 ## Contributing
 


### PR DESCRIPTION
Now we can make simple fields a ConVar as long as they are public and static. This has an advantage since it allows us to more easily assign default values and also no need to set get;set; methods, and saves time, yay!

Also fixed error when trying to print 'null' to console.

Also fixed typo in readme.md